### PR TITLE
Adds support for the vim-asterisk g:asterisk#keeppos setting

### DIFF
--- a/autoload/search_pulse.vim
+++ b/autoload/search_pulse.vim
@@ -79,10 +79,10 @@ func! search_pulse#Pulse()
 endf
 
 func! search_pulse#PulsePattern()
-  let pos = getpos('.')
+  let [line, col] = s:LocatePattern()
   let pattern =
-        \ '\%' . pos[1] . 'l' .
-        \ '\%' . pos[2] . 'c' .
+        \ '\%' . line . 'l' .
+        \ '\%' . col . 'c' .
         \ s:ScrubPattern(getreg('/'))
 
   if &ignorecase == 1 || &smartcase == 1
@@ -191,6 +191,15 @@ func! s:IsPatternOnTheSameLine()
   endif
 
   return s:old_line == line('.')
+endf
+
+func! s:LocatePattern()
+  " If the cursor isn't on the first char of the pattern, ...
+  if searchpos(getreg('/') . '\c', 'cn', line('.'))[1] != col('.')
+    " ... search backwards for the first char of the pattern.
+    return searchpos(getreg('/') . '\c', 'bn', line('.'))
+  endif
+  return [line('.'), col('.')]
 endf
 
 func! s:HandleFoldOpening()


### PR DESCRIPTION
When vim-asterisk is installed and [```g:asterisk#keeppos```](https://github.com/haya14busa/vim-asterisk#4-keep-cursor-position-across-matches) is set to 1, the cursor can potentially be offset within the pattern - this prevents vim-search-pulse from pulsing the pattern. This PR resolves the issue by locating the first char of the pattern if the cursor isn't already on it.

This is the minimal config I used to test the issue:

```VimL
let g:vim_search_pulse_disable_auto_mappings=1
let g:vim_search_pulse_mode='pattern'

let g:asterisk#keeppos=1
nmap * <Plug>(asterisk-*)<Plug>Pulse
nmap # <Plug>(asterisk-#)<Plug>Pulse
nmap n n<Plug>Pulse
nmap N N<Plug>Pulse
```