### PR TITLE
add doautocmd back with proper error checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ If you are using gvim, these are the default colors:
 
 To disable/enable set the value of `g:vim_search_pulse_disable` to 0 or 1
 
+To execute arbitrary commands before and after pulse runs, use these autocmds:
+
+    autocmd User PrePulse
+    autocmd User PostPulse
+
+For example, to turn on `cursorcolumn` during the pulse and then off right after:
+
+    augroup Pulse
+        autocmd! User PrePulse
+        autocmd! User PostPulse
+        autocmd  User PrePulse  set cursorcolumn
+        autocmd  User PostPulse set nocursorcolumn
+    augroup END
+
+This functionality requires Vim 7.3.438 or newer.
+
 ## Integration with the incsearch.vim plugin
 
 [incsearch.vim](https://github.com/haya14busa/incsearch.vim) provides a very

--- a/autoload/search_pulse.vim
+++ b/autoload/search_pulse.vim
@@ -71,10 +71,16 @@ func! search_pulse#Pulse()
   if get(s:, 'initialized') == 0
     call s:Initialize()
   endif
+  if has('patch-7.3.438')
+    silent doautocmd <nomodeline> User PrePulse
+  endif
   if g:vim_search_pulse_mode == 'pattern'
     call search_pulse#PulsePattern()
   elseif g:vim_search_pulse_mode == 'cursor_line'
     call search_pulse#PulseCursorLine()
+  endif
+  if has('patch-7.3.438')
+    silent doautocmd <nomodeline> User PostPulse
   endif
 endf
 

--- a/doc/search-pulse.txt
+++ b/doc/search-pulse.txt
@@ -84,6 +84,21 @@ If you are using gvim, these are the default colors:
 
 To disable/enable set the value of g:vim_search_pulse_disable to 0 or 1
 
+To execute arbitrary commands before and after pulse runs, use these autocmds:
+
+    autocmd User PrePulse
+    autocmd User PostPulse
+
+For example, to turn on cursorcolumn during the pulse and then off right after:
+
+    augroup Pulse
+        autocmd! User PrePulse
+        autocmd! User PostPulse
+        autocmd  User PrePulse  set cursorcolumn
+        autocmd  User PostPulse set nocursorcolumn
+    augroup END
+
+This functionality requires Vim 7.3.438 or newer.
 
 ==============================================================================
 3. Integration with other plugins                   *SearchPulseOtherPlugins*


### PR DESCRIPTION
sorry about that, should be all good now.

Without `<nomodeline>`, this functionality can be disruptive if you have a modeline, since it may mess with your folds and cause them to close up on you every time you hit n or N. Because of this, I opted to disable the functionality unless both the `:doautocmd` command, and the `<nomodeline>` argument to it are present. `<nomodeline>` was introduced in patch 7.3.438:

https://groups.google.com/forum/#!topic/vim_dev/wBQm2PTJdRI