### PR TITLE
Add pulse command

### DIFF
--- a/doc/search-pulse.txt
+++ b/doc/search-pulse.txt
@@ -151,6 +151,10 @@ star motions. Here's the configuration:
 ==============================================================================
 4. Commands                                             *SearchPulseCommands*
 
+:Pulse                                                               *:Pulse*
+
+Pulse the current line.
+
 :SearchPulseToggle                                       *:SearchPulseToggle*
 
 Easily switch the search pulse on and off.

--- a/plugin/search_pulse.vim
+++ b/plugin/search_pulse.vim
@@ -11,6 +11,7 @@ nnoremap
 nnoremap
       \ <silent>
       \ <SID>Pulse :call search_pulse#Pulse()<cr>
+command -nargs=0 Pulse :call search_pulse#Pulse()
 
 if get(g:, 'vim_search_pulse_disable_auto_mappings') != 0
   finish


### PR DESCRIPTION
This PR adds a new `:Pulse` command handy if one wanted to pulse the current from a `nnoremap` -- `<Plug>Pulse` can only be used with recursive maps.