### PR TITLE
Fix unwanted behaviour when pulsing in operator-pending mode (e.g. `c/<pattern>`)

### DIFF
--- a/autoload/search_pulse.vim
+++ b/autoload/search_pulse.vim
@@ -60,6 +60,9 @@ endf
 
 " Will pulse the cursor line on first search match using / or ?
 func! search_pulse#PulseFirst()
+  " state() doesn't exist on nvim
+  if has('nvim') | return "\<cr>" | endif
+
   let t = getcmdtype()
 
   if state() != "o" && (t == '/' || t == '?')

--- a/autoload/search_pulse.vim
+++ b/autoload/search_pulse.vim
@@ -62,7 +62,7 @@ endf
 func! search_pulse#PulseFirst()
   let t = getcmdtype()
 
-  if t == '/' || t == '?'
+  if state() != "o" && (t == '/' || t == '?')
     return "\<cr>:call search_pulse#Pulse()\<cr>"
   endif
 


### PR DESCRIPTION
I explained this in more detail in #23, feel free to let me know if there's anything more I can do. It doesn't work on nvim, but it's still a strict improvement as it'll at least fix it on Vim8.

Closes #23 

Closes #24